### PR TITLE
Replace uses of builtin substitution with custom semantics for lambda

### DIFF
--- a/1_k/1_lambda/lesson_2.5/lambda.k
+++ b/1_k/1_lambda/lesson_2.5/lambda.k
@@ -1,13 +1,11 @@
 // Copyright (c) Runtime Verification, Inc. All Rights Reserved.
 
-require "substitution.md"
-
 module LAMBDA-SYNTAX
   imports DOMAINS-SYNTAX
-  imports KVAR-SYNTAX
+  imports ID-SYNTAX
 
-  syntax Val ::= KVar
-               | "lambda" KVar "." Exp  [binder]
+  syntax Val ::= Id
+               | "lambda" Id "." Exp
   syntax Exp ::= Val
                | Exp Exp              [left]
                | "(" Exp ")"          [bracket]
@@ -15,15 +13,27 @@ endmodule
 
 module LAMBDA
   imports LAMBDA-SYNTAX
+  imports DOMAINS
 
-  syntax Exp ::= Exp "[" Exp "/" KVar "]" [function]
-  rule X:Val [_ / _] => X [owise]
+  syntax Set ::= freeVars( Exp ) [function]
+  rule freeVars( V:Id )         => SetItem(V)
+  rule freeVars( lambda X . E ) => freeVars( E ) -Set SetItem(X)
+  rule freeVars( E1 E2 )        => freeVars(E1) freeVars(E2)
 
+  syntax Id ::= freshVar(Id, Int, Set) [function]
+  rule freshVar(V, I, S) => #let X = String2Id(Id2String(V) +String Int2String(I)) #in #if X in S #then freshVar(V, I +Int 1, S) #else X #fi
+
+  syntax Exp ::= Exp "[" Exp "/" Id "]" [function]
+
+  rule X:Exp [_ / _] => X [owise]
   rule X [V / X] => V
 
-  rule (lambda X . E) [V / Y] => lambda X . (E[V / Y])
+  rule (lambda Y . E) [_ / Y] => lambda Y . E
+  rule (lambda Y . E) [V / X] => lambda Y . (E[V / X]) requires Y =/=K X andBool notBool (Y in freeVars(V))
+  rule (lambda Y . E) [V / X] => #let Z = freshVar(Y, 0, freeVars(E) freeVars(V)) #in lambda Z . (E[Z / Y] [V / X])
+    requires Y =/=K X andBool Y in freeVars(V)
 
   rule (E1:Exp E2:Exp) [V / X] => E1[V / X] (E2[V / X])
 
-  rule (lambda X:KVar . E:Exp) V:Val => E[V / X]   [anywhere]
+  rule (lambda X:Id . E:Exp) V:Val => E[V / X]   [anywhere]
 endmodule

--- a/1_k/1_lambda/lesson_2.5/lambda.k
+++ b/1_k/1_lambda/lesson_2.5/lambda.k
@@ -15,7 +15,15 @@ endmodule
 
 module LAMBDA
   imports LAMBDA-SYNTAX
-  imports SUBSTITUTION
+
+  syntax Exp ::= Exp "[" Exp "/" KVar "]" [function]
+  rule X:Val [_ / _] => X [owise]
+
+  rule X [V / X] => V
+
+  rule (lambda X . E) [V / Y] => lambda X . (E[V / Y])
+
+  rule (E1:Exp E2:Exp) [V / X] => E1[V / X] (E2[V / X])
 
   rule (lambda X:KVar . E:Exp) V:Val => E[V / X]   [anywhere]
 endmodule

--- a/1_k/1_lambda/lesson_2/lambda.k
+++ b/1_k/1_lambda/lesson_2/lambda.k
@@ -1,13 +1,11 @@
 // Copyright (c) Runtime Verification, Inc. All Rights Reserved.
 
-require "substitution.md"
-
 module LAMBDA-SYNTAX
   imports DOMAINS-SYNTAX
-  imports KVAR-SYNTAX
+  imports ID-SYNTAX
 
-  syntax Val ::= KVar
-               | "lambda" KVar "." Exp  [binder]
+  syntax Val ::= Id
+               | "lambda" Id "." Exp
   syntax Exp ::= Val
                | Exp Exp              [left]
                | "(" Exp ")"          [bracket]
@@ -15,15 +13,27 @@ endmodule
 
 module LAMBDA
   imports LAMBDA-SYNTAX
+  imports DOMAINS
 
-  syntax Exp ::= Exp "[" Exp "/" KVar "]" [function]
-  rule X:Val [_ / _] => X [owise]
+  syntax Set ::= freeVars( Exp ) [function]
+  rule freeVars( V:Id )         => SetItem(V)
+  rule freeVars( lambda X . E ) => freeVars( E ) -Set SetItem(X)
+  rule freeVars( E1 E2 )        => freeVars(E1) freeVars(E2)
 
+  syntax Id ::= freshVar(Id, Int, Set) [function]
+  rule freshVar(V, I, S) => #let X = String2Id(Id2String(V) +String Int2String(I)) #in #if X in S #then freshVar(V, I +Int 1, S) #else X #fi
+
+  syntax Exp ::= Exp "[" Exp "/" Id "]" [function]
+
+  rule X:Exp [_ / _] => X [owise]
   rule X [V / X] => V
 
-  rule (lambda X . E) [V / Y] => lambda X . (E[V / Y])
+  rule (lambda Y . E) [_ / Y] => lambda Y . E
+  rule (lambda Y . E) [V / X] => lambda Y . (E[V / X]) requires Y =/=K X andBool notBool (Y in freeVars(V))
+  rule (lambda Y . E) [V / X] => #let Z = freshVar(Y, 0, freeVars(E) freeVars(V)) #in lambda Z . (E[Z / Y] [V / X])
+    requires Y =/=K X andBool Y in freeVars(V)
 
   rule (E1:Exp E2:Exp) [V / X] => E1[V / X] (E2[V / X])
 
-  rule (lambda X:KVar . E:Exp) V:Val => E[V / X]
+  rule (lambda X:Id . E:Exp) V:Val => E[V / X]
 endmodule

--- a/1_k/1_lambda/lesson_2/lambda.k
+++ b/1_k/1_lambda/lesson_2/lambda.k
@@ -15,7 +15,15 @@ endmodule
 
 module LAMBDA
   imports LAMBDA-SYNTAX
-  imports SUBSTITUTION
+
+  syntax Exp ::= Exp "[" Exp "/" KVar "]" [function]
+  rule X:Val [_ / _] => X [owise]
+
+  rule X [V / X] => V
+
+  rule (lambda X . E) [V / Y] => lambda X . (E[V / Y])
+
+  rule (E1:Exp E2:Exp) [V / X] => E1[V / X] (E2[V / X])
 
   rule (lambda X:KVar . E:Exp) V:Val => E[V / X]
 endmodule

--- a/1_k/1_lambda/lesson_2/tests/closed-variable-capture.lambda.out
+++ b/1_k/1_lambda/lesson_2/tests/closed-variable-capture.lambda.out
@@ -1,3 +1,3 @@
 <k>
-  lambda y . ( ( lambda x . lambda y0 . ( x y0 ) ) y ) ~> .
+  lambda y . ( ( lambda x . lambda y . ( x y ) ) y ) ~> .
 </k>

--- a/1_k/1_lambda/lesson_2/tests/free-variable-capture.lambda.out
+++ b/1_k/1_lambda/lesson_2/tests/free-variable-capture.lambda.out
@@ -1,3 +1,3 @@
 <k>
-  a ( ( lambda x . lambda y . x ) y0 z ) ~> .
+  a ( ( lambda x . lambda y . x ) y z ) ~> .
 </k>

--- a/1_k/1_lambda/lesson_3/lambda.k
+++ b/1_k/1_lambda/lesson_3/lambda.k
@@ -15,7 +15,15 @@ endmodule
 
 module LAMBDA
   imports LAMBDA-SYNTAX
-  imports SUBSTITUTION
+
+  syntax Exp ::= Exp "[" Exp "/" KVar "]" [function]
+  rule X:Val [_ / _] => X [owise]
+
+  rule X [V / X] => V
+
+  rule (lambda X . E) [V / Y] => lambda X . (E[V / Y])
+
+  rule (E1:Exp E2:Exp) [V / X] => E1[V / X] (E2[V / X])
 
   syntax KResult ::= Val
 

--- a/1_k/1_lambda/lesson_3/lambda.k
+++ b/1_k/1_lambda/lesson_3/lambda.k
@@ -1,13 +1,11 @@
 // Copyright (c) Runtime Verification, Inc. All Rights Reserved.
 
-require "substitution.md"
-
 module LAMBDA-SYNTAX
   imports DOMAINS-SYNTAX
-  imports KVAR-SYNTAX
+  imports ID-SYNTAX
 
-  syntax Val ::= KVar
-               | "lambda" KVar "." Exp  [binder]
+  syntax Val ::= Id
+               | "lambda" Id "." Exp
   syntax Exp ::= Val
                | Exp Exp              [strict, left]
                | "(" Exp ")"          [bracket]
@@ -15,17 +13,29 @@ endmodule
 
 module LAMBDA
   imports LAMBDA-SYNTAX
+  imports DOMAINS
 
-  syntax Exp ::= Exp "[" Exp "/" KVar "]" [function]
-  rule X:Val [_ / _] => X [owise]
+  syntax Set ::= freeVars( Exp ) [function]
+  rule freeVars( V:Id )         => SetItem(V)
+  rule freeVars( lambda X . E ) => freeVars( E ) -Set SetItem(X)
+  rule freeVars( E1 E2 )        => freeVars(E1) freeVars(E2)
 
+  syntax Id ::= freshVar(Id, Int, Set) [function]
+  rule freshVar(V, I, S) => #let X = String2Id(Id2String(V) +String Int2String(I)) #in #if X in S #then freshVar(V, I +Int 1, S) #else X #fi
+
+  syntax Exp ::= Exp "[" Exp "/" Id "]" [function]
+
+  rule X:Exp [_ / _] => X [owise]
   rule X [V / X] => V
 
-  rule (lambda X . E) [V / Y] => lambda X . (E[V / Y])
+  rule (lambda Y . E) [_ / Y] => lambda Y . E
+  rule (lambda Y . E) [V / X] => lambda Y . (E[V / X]) requires Y =/=K X andBool notBool (Y in freeVars(V))
+  rule (lambda Y . E) [V / X] => #let Z = freshVar(Y, 0, freeVars(E) freeVars(V)) #in lambda Z . (E[Z / Y] [V / X])
+    requires Y =/=K X andBool Y in freeVars(V)
 
   rule (E1:Exp E2:Exp) [V / X] => E1[V / X] (E2[V / X])
 
   syntax KResult ::= Val
 
-  rule (lambda X:KVar . E:Exp) V:Val => E[V / X]
+  rule (lambda X:Id . E:Exp) V:Val => E[V / X]
 endmodule

--- a/1_k/1_lambda/lesson_3/tests/closed-variable-capture.lambda.out
+++ b/1_k/1_lambda/lesson_3/tests/closed-variable-capture.lambda.out
@@ -1,3 +1,3 @@
 <k>
-  lambda y . ( ( lambda x . lambda y0 . ( x y0 ) ) y ) ~> .
+  lambda y . ( ( lambda x . lambda y . ( x y ) ) y ) ~> .
 </k>

--- a/1_k/1_lambda/lesson_4/lambda.k
+++ b/1_k/1_lambda/lesson_4/lambda.k
@@ -15,7 +15,15 @@ endmodule
 
 module LAMBDA
   imports LAMBDA-SYNTAX
-  imports SUBSTITUTION
+
+  syntax Exp ::= Exp "[" Exp "/" KVar "]" [function]
+  rule X:Val [_ / _] => X [owise]
+
+  rule X [V / X] => V
+
+  rule (lambda X . E) [V / Y] => lambda X . (E[V / Y])
+
+  rule (E1:Exp E2:Exp) [V / X] => E1[V / X] (E2[V / X])
 
   syntax KResult ::= Val
 

--- a/1_k/1_lambda/lesson_4/lambda.k
+++ b/1_k/1_lambda/lesson_4/lambda.k
@@ -1,13 +1,11 @@
 // Copyright (c) Runtime Verification, Inc. All Rights Reserved.
 
-require "substitution.md"
-
 module LAMBDA-SYNTAX
   imports DOMAINS-SYNTAX
-  imports KVAR-SYNTAX
+  imports ID-SYNTAX
 
-  syntax Val ::= KVar
-               | "lambda" KVar "." Exp  [binder, latex(\lambda{#1}.{#2})]
+  syntax Val ::= Id
+               | "lambda" Id "." Exp  [latex(\lambda{#1}.{#2})]
   syntax Exp ::= Val
                | Exp Exp              [strict, left]
                | "(" Exp ")"          [bracket]
@@ -15,17 +13,29 @@ endmodule
 
 module LAMBDA
   imports LAMBDA-SYNTAX
+  imports DOMAINS
 
-  syntax Exp ::= Exp "[" Exp "/" KVar "]" [function]
-  rule X:Val [_ / _] => X [owise]
+  syntax Set ::= freeVars( Exp ) [function]
+  rule freeVars( V:Id )         => SetItem(V)
+  rule freeVars( lambda X . E ) => freeVars( E ) -Set SetItem(X)
+  rule freeVars( E1 E2 )        => freeVars(E1) freeVars(E2)
 
+  syntax Id ::= freshVar(Id, Int, Set) [function]
+  rule freshVar(V, I, S) => #let X = String2Id(Id2String(V) +String Int2String(I)) #in #if X in S #then freshVar(V, I +Int 1, S) #else X #fi
+
+  syntax Exp ::= Exp "[" Exp "/" Id "]" [function]
+
+  rule X:Exp [_ / _] => X [owise]
   rule X [V / X] => V
 
-  rule (lambda X . E) [V / Y] => lambda X . (E[V / Y])
+  rule (lambda Y . E) [_ / Y] => lambda Y . E
+  rule (lambda Y . E) [V / X] => lambda Y . (E[V / X]) requires Y =/=K X andBool notBool (Y in freeVars(V))
+  rule (lambda Y . E) [V / X] => #let Z = freshVar(Y, 0, freeVars(E) freeVars(V)) #in lambda Z . (E[Z / Y] [V / X])
+    requires Y =/=K X andBool Y in freeVars(V)
 
   rule (E1:Exp E2:Exp) [V / X] => E1[V / X] (E2[V / X])
 
   syntax KResult ::= Val
 
-  rule (lambda X:KVar . E:Exp) V:Val => E[V / X]
+  rule (lambda X:Id . E:Exp) V:Val => E[V / X]
 endmodule

--- a/1_k/1_lambda/lesson_4/tests/closed-variable-capture.lambda.out
+++ b/1_k/1_lambda/lesson_4/tests/closed-variable-capture.lambda.out
@@ -1,3 +1,3 @@
 <k>
-  lambda y . ( ( lambda x . lambda y0 . ( x y0 ) ) y ) ~> .
+  lambda y . ( ( lambda x . lambda y . ( x y ) ) y ) ~> .
 </k>

--- a/1_k/1_lambda/lesson_5/lambda.k
+++ b/1_k/1_lambda/lesson_5/lambda.k
@@ -22,8 +22,21 @@ endmodule
 
 module LAMBDA
   imports LAMBDA-SYNTAX
-  imports SUBSTITUTION
   imports DOMAINS
+
+  syntax Exp ::= Exp "[" Exp "/" KVar "]" [function]
+  rule X:Val [_ / _] => X [owise]
+
+  rule X [V / X] => V
+
+  rule (lambda X . E) [V / Y] => lambda X . (E[V / Y])
+
+  rule (E1:Exp E2:Exp) [V / X] => E1[V / X] (E2[V / X])
+
+  rule (E1:Exp *  E2:Exp) [V / X] => E1[V / X] *  (E2[V / X])
+  rule (E1:Exp /  E2:Exp) [V / X] => E1[V / X] /  (E2[V / X])
+  rule (E1:Exp +  E2:Exp) [V / X] => E1[V / X] +  (E2[V / X])
+  rule (E1:Exp <= E2:Exp) [V / X] => E1[V / X] <= (E2[V / X])
 
   syntax KResult ::= Val
 

--- a/1_k/1_lambda/lesson_5/lambda.k
+++ b/1_k/1_lambda/lesson_5/lambda.k
@@ -1,13 +1,11 @@
 // Copyright (c) Runtime Verification, Inc. All Rights Reserved.
 
-require "substitution.md"
-
 module LAMBDA-SYNTAX
   imports DOMAINS-SYNTAX
-  imports KVAR-SYNTAX
+  imports ID-SYNTAX
 
-  syntax Val ::= KVar
-               | "lambda" KVar "." Exp  [binder, latex(\lambda{#1}.{#2})]
+  syntax Val ::= Id
+               | "lambda" Id "." Exp  [latex(\lambda{#1}.{#2})]
   syntax Exp ::= Val
                | Exp Exp              [strict, left]
                | "(" Exp ")"          [bracket]
@@ -24,12 +22,28 @@ module LAMBDA
   imports LAMBDA-SYNTAX
   imports DOMAINS
 
-  syntax Exp ::= Exp "[" Exp "/" KVar "]" [function]
-  rule X:Val [_ / _] => X [owise]
+  syntax Set ::= freeVars( Exp ) [function]
+  rule freeVars( _ )            => .Set [owise]
+  rule freeVars( V:Id )         => SetItem(V)
+  rule freeVars( lambda X . E ) => freeVars( E ) -Set SetItem(X)
+  rule freeVars( E1 E2 )        => freeVars(E1) freeVars(E2)
+  rule freeVars( E1 * E2 )      => freeVars(E1) freeVars(E2)
+  rule freeVars( E1 / E2 )      => freeVars(E1) freeVars(E2)
+  rule freeVars( E1 + E2 )      => freeVars(E1) freeVars(E2)
+  rule freeVars( E1 <= E2 )     => freeVars(E1) freeVars(E2)
 
+  syntax Id ::= freshVar(Id, Int, Set) [function]
+  rule freshVar(V, I, S) => #let X = String2Id(Id2String(V) +String Int2String(I)) #in #if X in S #then freshVar(V, I +Int 1, S) #else X #fi
+
+  syntax Exp ::= Exp "[" Exp "/" Id "]" [function]
+
+  rule X:Exp [_ / _] => X [owise]
   rule X [V / X] => V
 
-  rule (lambda X . E) [V / Y] => lambda X . (E[V / Y])
+  rule (lambda Y . E) [_ / Y] => lambda Y . E
+  rule (lambda Y . E) [V / X] => lambda Y . (E[V / X]) requires Y =/=K X andBool notBool (Y in freeVars(V))
+  rule (lambda Y . E) [V / X] => #let Z = freshVar(Y, 0, freeVars(E) freeVars(V)) #in lambda Z . (E[Z / Y] [V / X])
+    requires Y =/=K X andBool Y in freeVars(V)
 
   rule (E1:Exp E2:Exp) [V / X] => E1[V / X] (E2[V / X])
 
@@ -40,7 +54,7 @@ module LAMBDA
 
   syntax KResult ::= Val
 
-  rule (lambda X:KVar . E:Exp) V:Val => E[V / X]
+  rule (lambda X:Id . E:Exp) V:Val => E[V / X]
 
   rule - I => 0 -Int I
   rule I1 * I2 => I1 *Int I2

--- a/1_k/1_lambda/lesson_5/tests/closed-variable-capture.lambda.out
+++ b/1_k/1_lambda/lesson_5/tests/closed-variable-capture.lambda.out
@@ -1,3 +1,3 @@
 <k>
-  lambda y . ( ( lambda x . lambda y0 . ( x y0 ) ) y ) ~> .
+  lambda y . ( ( lambda x . lambda y . ( x y ) ) y ) ~> .
 </k>

--- a/1_k/1_lambda/lesson_6/lambda.k
+++ b/1_k/1_lambda/lesson_6/lambda.k
@@ -1,13 +1,11 @@
 // Copyright (c) Runtime Verification, Inc. All Rights Reserved.
 
-require "substitution.md"
-
 module LAMBDA-SYNTAX
   imports DOMAINS-SYNTAX
-  imports KVAR-SYNTAX
+  imports ID-SYNTAX
 
-  syntax Val ::= KVar
-               | "lambda" KVar "." Exp  [binder, latex(\lambda{#1}.{#2})]
+  syntax Val ::= Id
+               | "lambda" Id "." Exp  [latex(\lambda{#1}.{#2})]
   syntax Exp ::= Val
                | Exp Exp              [strict, left]
                | "(" Exp ")"          [bracket]
@@ -26,12 +24,29 @@ module LAMBDA
   imports LAMBDA-SYNTAX
   imports DOMAINS
 
-  syntax Exp ::= Exp "[" Exp "/" KVar "]" [function]
-  rule X:Val [_ / _] => X [owise]
+  syntax Set ::= freeVars( Exp ) [function]
+  rule freeVars( _ )            => .Set [owise]
+  rule freeVars( V:Id )         => SetItem(V)
+  rule freeVars( lambda X . E ) => freeVars( E ) -Set SetItem(X)
+  rule freeVars( E1 E2 )        => freeVars(E1) freeVars(E2)
+  rule freeVars( E1 * E2 )      => freeVars(E1) freeVars(E2)
+  rule freeVars( E1 / E2 )      => freeVars(E1) freeVars(E2)
+  rule freeVars( E1 + E2 )      => freeVars(E1) freeVars(E2)
+  rule freeVars( E1 <= E2 )     => freeVars(E1) freeVars(E2)
+  rule freeVars( if B then E1 else E2) => freeVars(B) freeVars(E1) freeVars(E2)
 
+  syntax Id ::= freshVar(Id, Int, Set) [function]
+  rule freshVar(V, I, S) => #let X = String2Id(Id2String(V) +String Int2String(I)) #in #if X in S #then freshVar(V, I +Int 1, S) #else X #fi
+
+  syntax Exp ::= Exp "[" Exp "/" Id "]" [function]
+
+  rule X:Exp [_ / _] => X [owise]
   rule X [V / X] => V
 
-  rule (lambda X . E) [V / Y] => lambda X . (E[V / Y])
+  rule (lambda Y . E) [_ / Y] => lambda Y . E
+  rule (lambda Y . E) [V / X] => lambda Y . (E[V / X]) requires Y =/=K X andBool notBool (Y in freeVars(V))
+  rule (lambda Y . E) [V / X] => #let Z = freshVar(Y, 0, freeVars(E) freeVars(V)) #in lambda Z . (E[Z / Y] [V / X])
+    requires Y =/=K X andBool Y in freeVars(V)
 
   rule (E1:Exp E2:Exp) [V / X] => E1[V / X] (E2[V / X])
 
@@ -44,7 +59,7 @@ module LAMBDA
 
   syntax KResult ::= Val
 
-  rule (lambda X:KVar . E:Exp) V:Val => E[V / X]
+  rule (lambda X:Id . E:Exp) V:Val => E[V / X]
 
   rule - I => 0 -Int I
   rule I1 * I2 => I1 *Int I2

--- a/1_k/1_lambda/lesson_6/lambda.k
+++ b/1_k/1_lambda/lesson_6/lambda.k
@@ -24,8 +24,23 @@ endmodule
 
 module LAMBDA
   imports LAMBDA-SYNTAX
-  imports SUBSTITUTION
   imports DOMAINS
+
+  syntax Exp ::= Exp "[" Exp "/" KVar "]" [function]
+  rule X:Val [_ / _] => X [owise]
+
+  rule X [V / X] => V
+
+  rule (lambda X . E) [V / Y] => lambda X . (E[V / Y])
+
+  rule (E1:Exp E2:Exp) [V / X] => E1[V / X] (E2[V / X])
+
+  rule (E1:Exp *  E2:Exp) [V / X] => E1[V / X] *  (E2[V / X])
+  rule (E1:Exp /  E2:Exp) [V / X] => E1[V / X] /  (E2[V / X])
+  rule (E1:Exp +  E2:Exp) [V / X] => E1[V / X] +  (E2[V / X])
+  rule (E1:Exp <= E2:Exp) [V / X] => E1[V / X] <= (E2[V / X])
+
+  rule (if C then E1 else E2) [V / X] => if C[V / X] then E1[V / X] else (E2[V / X])
 
   syntax KResult ::= Val
 

--- a/1_k/1_lambda/lesson_6/tests/closed-variable-capture.lambda.out
+++ b/1_k/1_lambda/lesson_6/tests/closed-variable-capture.lambda.out
@@ -1,3 +1,3 @@
 <k>
-  lambda y . ( ( lambda x . lambda y0 . ( x y0 ) ) y ) ~> .
+  lambda y . ( ( lambda x . lambda y . ( x y ) ) y ) ~> .
 </k>

--- a/1_k/1_lambda/lesson_7/lambda.k
+++ b/1_k/1_lambda/lesson_7/lambda.k
@@ -35,8 +35,23 @@ endmodule
 
 module LAMBDA
   imports LAMBDA-SYNTAX
-  imports SUBSTITUTION
   imports DOMAINS
+
+  syntax Exp ::= Exp "[" Exp "/" KVar "]" [function]
+  rule X:Exp [_ / _] => X [owise]
+
+  rule X [V / X] => V
+
+  rule (lambda X . E) [V / Y] => lambda X . (E[V / Y])
+
+  rule (E1:Exp E2:Exp) [V / X] => E1[V / X] (E2[V / X])
+
+  rule (E1:Exp *  E2:Exp) [V / X] => E1[V / X] *  (E2[V / X])
+  rule (E1:Exp /  E2:Exp) [V / X] => E1[V / X] /  (E2[V / X])
+  rule (E1:Exp +  E2:Exp) [V / X] => E1[V / X] +  (E2[V / X])
+  rule (E1:Exp <= E2:Exp) [V / X] => E1[V / X] <= (E2[V / X])
+
+  rule (if C then E1 else E2) [V / X] => if C[V / X] then E1[V / X] else (E2[V / X])
 
   syntax KResult ::= Val
 

--- a/1_k/1_lambda/lesson_7/lambda.k
+++ b/1_k/1_lambda/lesson_7/lambda.k
@@ -1,13 +1,11 @@
 // Copyright (c) Runtime Verification, Inc. All Rights Reserved.
 
-require "substitution.md"
-
 module LAMBDA-SYNTAX
   imports DOMAINS-SYNTAX
-  imports KVAR-SYNTAX
+  imports ID-SYNTAX
 
-  syntax Val ::= KVar
-               | "lambda" KVar "." Exp  [binder, latex(\lambda{#1}.{#2})]
+  syntax Val ::= Id
+               | "lambda" Id "." Exp  [latex(\lambda{#1}.{#2})]
   syntax Exp ::= Val
                | Exp Exp              [strict, left]
                | "(" Exp ")"          [bracket]
@@ -21,12 +19,12 @@ module LAMBDA-SYNTAX
 
   syntax Exp ::= "if" Exp "then" Exp "else" Exp  [strict(1)]
 
-  syntax Exp ::= "let" KVar "=" Exp "in" Exp [macro]
+  syntax Exp ::= "let" Id "=" Exp "in" Exp [macro]
   rule let X = E in E':Exp => (lambda X . E') E
 
-  syntax Exp ::= "letrec" KVar KVar "=" Exp "in" Exp [macro]
-  syntax KVar ::= "$x" [token] | "$y" [token]
-  rule letrec F:KVar X:KVar = E in E'
+  syntax Exp ::= "letrec" Id Id "=" Exp "in" Exp [macro]
+  syntax Id ::= "$x" [token] | "$y" [token]
+  rule letrec F:Id X:Id = E in E'
     => let F =
          (lambda $x . ((lambda F . lambda X . E) (lambda $y . ($x $x $y))))
          (lambda $x . ((lambda F . lambda X . E) (lambda $y . ($x $x $y))))
@@ -37,12 +35,29 @@ module LAMBDA
   imports LAMBDA-SYNTAX
   imports DOMAINS
 
-  syntax Exp ::= Exp "[" Exp "/" KVar "]" [function]
-  rule X:Exp [_ / _] => X [owise]
+  syntax Set ::= freeVars( Exp ) [function]
+  rule freeVars( _ )            => .Set [owise]
+  rule freeVars( V:Id )         => SetItem(V)
+  rule freeVars( lambda X . E ) => freeVars( E ) -Set SetItem(X)
+  rule freeVars( E1 E2 )        => freeVars(E1) freeVars(E2)
+  rule freeVars( E1 * E2 )      => freeVars(E1) freeVars(E2)
+  rule freeVars( E1 / E2 )      => freeVars(E1) freeVars(E2)
+  rule freeVars( E1 + E2 )      => freeVars(E1) freeVars(E2)
+  rule freeVars( E1 <= E2 )     => freeVars(E1) freeVars(E2)
+  rule freeVars( if B then E1 else E2) => freeVars(B) freeVars(E1) freeVars(E2)
 
+  syntax Id ::= freshVar(Id, Int, Set) [function]
+  rule freshVar(V, I, S) => #let X = String2Id(Id2String(V) +String Int2String(I)) #in #if X in S #then freshVar(V, I +Int 1, S) #else X #fi
+
+  syntax Exp ::= Exp "[" Exp "/" Id "]" [function]
+
+  rule X:Exp [_ / _] => X [owise]
   rule X [V / X] => V
 
-  rule (lambda X . E) [V / Y] => lambda X . (E[V / Y])
+  rule (lambda Y . E) [_ / Y] => lambda Y . E
+  rule (lambda Y . E) [V / X] => lambda Y . (E[V / X]) requires Y =/=K X andBool notBool (Y in freeVars(V))
+  rule (lambda Y . E) [V / X] => #let Z = freshVar(Y, 0, freeVars(E) freeVars(V)) #in lambda Z . (E[Z / Y] [V / X])
+    requires Y =/=K X andBool Y in freeVars(V)
 
   rule (E1:Exp E2:Exp) [V / X] => E1[V / X] (E2[V / X])
 
@@ -55,7 +70,7 @@ module LAMBDA
 
   syntax KResult ::= Val
 
-  rule (lambda X:KVar . E:Exp) V:Val => E[V / X]
+  rule (lambda X:Id . E:Exp) V:Val => E[V / X]
 
   rule - I => 0 -Int I
   rule I1 * I2 => I1 *Int I2

--- a/1_k/1_lambda/lesson_7/tests/closed-variable-capture.lambda.out
+++ b/1_k/1_lambda/lesson_7/tests/closed-variable-capture.lambda.out
@@ -1,3 +1,3 @@
 <k>
-  lambda y . ( ( lambda x . lambda y0 . ( x y0 ) ) y ) ~> .
+  lambda y . ( ( lambda x . lambda y . ( x y ) ) y ) ~> .
 </k>

--- a/1_k/1_lambda/lesson_8/lambda.k
+++ b/1_k/1_lambda/lesson_8/lambda.k
@@ -31,8 +31,23 @@ endmodule
 
 module LAMBDA
   imports LAMBDA-SYNTAX
-  imports SUBSTITUTION
   imports DOMAINS
+
+  syntax Exp ::= Exp "[" Exp "/" KVar "]" [function]
+  rule X:Exp [_ / _] => X [owise]
+
+  rule X [V / X] => V
+
+  rule (lambda X . E) [V / Y] => lambda X . (E[V / Y])
+
+  rule (E1:Exp E2:Exp) [V / X] => E1[V / X] (E2[V / X])
+
+  rule (E1:Exp *  E2:Exp) [V / X] => E1[V / X] *  (E2[V / X])
+  rule (E1:Exp /  E2:Exp) [V / X] => E1[V / X] /  (E2[V / X])
+  rule (E1:Exp +  E2:Exp) [V / X] => E1[V / X] +  (E2[V / X])
+  rule (E1:Exp <= E2:Exp) [V / X] => E1[V / X] <= (E2[V / X])
+
+  rule (if C then E1 else E2) [V / X] => if C[V / X] then E1[V / X] else (E2[V / X])
 
   syntax KResult ::= Val
 

--- a/1_k/1_lambda/lesson_8/lambda.k
+++ b/1_k/1_lambda/lesson_8/lambda.k
@@ -1,13 +1,11 @@
 // Copyright (c) Runtime Verification, Inc. All Rights Reserved.
 
-require "substitution.md"
-
 module LAMBDA-SYNTAX
   imports DOMAINS-SYNTAX
-  imports KVAR-SYNTAX
+  imports ID-SYNTAX
 
-  syntax Val ::= KVar
-               | "lambda" KVar "." Exp  [binder, latex(\lambda{#1}.{#2})]
+  syntax Val ::= Id
+               | "lambda" Id "." Exp  [latex(\lambda{#1}.{#2})]
   syntax Exp ::= Val
                | Exp Exp              [strict, left]
                | "(" Exp ")"          [bracket]
@@ -21,24 +19,41 @@ module LAMBDA-SYNTAX
 
   syntax Exp ::= "if" Exp "then" Exp "else" Exp  [strict(1)]
 
-  syntax Exp ::= "let" KVar "=" Exp "in" Exp [macro]
+  syntax Exp ::= "let" Id "=" Exp "in" Exp [macro]
   rule let X = E in E':Exp => (lambda X . E') E
 
-  syntax Exp ::= "letrec" KVar KVar "=" Exp "in" Exp [macro]
-               | "mu" KVar "." Exp                   [binder, latex(\mu{#1}.{#2})]
-  rule letrec F:KVar X = E in E' => let F = mu F . lambda X . E in E'
+  syntax Exp ::= "letrec" Id Id "=" Exp "in" Exp [macro]
+               | "mu" Id "." Exp                   [latex(\mu{#1}.{#2})]
+  rule letrec F:Id X = E in E' => let F = mu F . lambda X . E in E'
 endmodule
 
 module LAMBDA
   imports LAMBDA-SYNTAX
   imports DOMAINS
 
-  syntax Exp ::= Exp "[" Exp "/" KVar "]" [function]
-  rule X:Exp [_ / _] => X [owise]
+  syntax Set ::= freeVars( Exp ) [function]
+  rule freeVars( _ )            => .Set [owise]
+  rule freeVars( V:Id )         => SetItem(V)
+  rule freeVars( lambda X . E ) => freeVars( E ) -Set SetItem(X)
+  rule freeVars( E1 E2 )        => freeVars(E1) freeVars(E2)
+  rule freeVars( E1 * E2 )      => freeVars(E1) freeVars(E2)
+  rule freeVars( E1 / E2 )      => freeVars(E1) freeVars(E2)
+  rule freeVars( E1 + E2 )      => freeVars(E1) freeVars(E2)
+  rule freeVars( E1 <= E2 )     => freeVars(E1) freeVars(E2)
+  rule freeVars( if B then E1 else E2) => freeVars(B) freeVars(E1) freeVars(E2)
 
+  syntax Id ::= freshVar(Id, Int, Set) [function]
+  rule freshVar(V, I, S) => #let X = String2Id(Id2String(V) +String Int2String(I)) #in #if X in S #then freshVar(V, I +Int 1, S) #else X #fi
+
+  syntax Exp ::= Exp "[" Exp "/" Id "]" [function]
+
+  rule X:Exp [_ / _] => X [owise]
   rule X [V / X] => V
 
-  rule (lambda X . E) [V / Y] => lambda X . (E[V / Y])
+  rule (lambda Y . E) [_ / Y] => lambda Y . E
+  rule (lambda Y . E) [V / X] => lambda Y . (E[V / X]) requires Y =/=K X andBool notBool (Y in freeVars(V))
+  rule (lambda Y . E) [V / X] => #let Z = freshVar(Y, 0, freeVars(E) freeVars(V)) #in lambda Z . (E[Z / Y] [V / X])
+    requires Y =/=K X andBool Y in freeVars(V)
 
   rule (E1:Exp E2:Exp) [V / X] => E1[V / X] (E2[V / X])
 
@@ -51,7 +66,7 @@ module LAMBDA
 
   syntax KResult ::= Val
 
-  rule (lambda X:KVar . E:Exp) V:Val => E[V / X]
+  rule (lambda X:Id . E:Exp) V:Val => E[V / X]
 
   rule - I => 0 -Int I
   rule I1 * I2 => I1 *Int I2

--- a/1_k/1_lambda/lesson_8/tests/closed-variable-capture.lambda.out
+++ b/1_k/1_lambda/lesson_8/tests/closed-variable-capture.lambda.out
@@ -1,3 +1,3 @@
 <k>
-  lambda y . ( ( lambda x . lambda y0 . ( x y0 ) ) y ) ~> .
+  lambda y . ( ( lambda x . lambda y . ( x y ) ) y ) ~> .
 </k>

--- a/1_k/1_lambda/lesson_9/lambda.md
+++ b/1_k/1_lambda/lesson_9/lambda.md
@@ -135,7 +135,6 @@ endmodule
 ```k
 module LAMBDA
   imports LAMBDA-SYNTAX
-  imports SUBSTITUTION
   imports DOMAINS
 
   syntax KResult ::= Val
@@ -144,6 +143,22 @@ module LAMBDA
 ### β-reduction
 
 ```k
+  syntax Exp ::= Exp "[" Exp "/" KVar "]" [function]
+  rule X:Exp [_ / _] => X [owise]
+
+  rule X [V / X] => V
+
+  rule (lambda X . E) [V / Y] => lambda X . (E[V / Y])
+
+  rule (E1:Exp E2:Exp) [V / X] => E1[V / X] (E2[V / X])
+
+  rule (E1:Exp *  E2:Exp) [V / X] => E1[V / X] *  (E2[V / X])
+  rule (E1:Exp /  E2:Exp) [V / X] => E1[V / X] /  (E2[V / X])
+  rule (E1:Exp +  E2:Exp) [V / X] => E1[V / X] +  (E2[V / X])
+  rule (E1:Exp <= E2:Exp) [V / X] => E1[V / X] <= (E2[V / X])
+
+  rule (if C then E1 else E2) [V / X] => if C[V / X] then E1[V / X] else (E2[V / X])
+
   rule (lambda X:KVar . E:Exp) V:Val => E[V / X]
 ```
 

--- a/1_k/1_lambda/lesson_9/lambda.md
+++ b/1_k/1_lambda/lesson_9/lambda.md
@@ -51,11 +51,9 @@ below.  Then we should make sure we import its module called SUBSTITUTION
 in our LAMBDA module below.
 
 ```k
-require "substitution.md"
-
 module LAMBDA-SYNTAX
   imports DOMAINS-SYNTAX
-  imports KVAR-SYNTAX
+  imports ID-SYNTAX
 ```
 ### Basic Call-by-value λ-Calculus Syntax
 
@@ -77,8 +75,8 @@ interleaved) order.
 
 The initial syntax of our λ-calculus:
 ```k
-  syntax Val ::= KVar
-               | "lambda" KVar "." Exp  [binder, latex(\lambda{#1}.{#2})]
+  syntax Val ::= Id
+               | "lambda" Id "." Exp  [latex(\lambda{#1}.{#2})]
   syntax Exp ::= Val
                | Exp Exp              [left, strict]
                | "(" Exp ")"          [bracket]
@@ -114,7 +112,7 @@ Note that the `if` construct is strict only in its first argument.
 The let binder is a derived construct, because it can be defined using λ.
 
 ```k
-  syntax Exp ::= "let" KVar "=" Exp "in" Exp [macro]
+  syntax Exp ::= "let" Id "=" Exp "in" Exp [macro]
   rule let X = E in E':Exp => (lambda X . E') E
 ```
 
@@ -124,9 +122,9 @@ really necessary, but it makes the definition of letrec easier to understand
 and faster to execute.
 
 ```k
-  syntax Exp ::= "letrec" KVar KVar "=" Exp "in" Exp [macro]
-               | "mu" KVar "." Exp                   [binder, latex(\mu{#1}.{#2})]
-  rule letrec F:KVar X:KVar = E in E' => let F = mu F . lambda X . E in E'
+  syntax Exp ::= "letrec" Id Id "=" Exp "in" Exp [macro]
+               | "mu" Id "." Exp                   [latex(\mu{#1}.{#2})]
+  rule letrec F:Id X:Id = E in E' => let F = mu F . lambda X . E in E'
 endmodule
 ```
 
@@ -143,12 +141,29 @@ module LAMBDA
 ### β-reduction
 
 ```k
-  syntax Exp ::= Exp "[" Exp "/" KVar "]" [function]
-  rule X:Exp [_ / _] => X [owise]
+  syntax Set ::= freeVars( Exp ) [function]
+  rule freeVars( _ )            => .Set [owise]
+  rule freeVars( V:Id )         => SetItem(V)
+  rule freeVars( lambda X . E ) => freeVars( E ) -Set SetItem(X)
+  rule freeVars( E1 E2 )        => freeVars(E1) freeVars(E2)
+  rule freeVars( E1 * E2 )      => freeVars(E1) freeVars(E2)
+  rule freeVars( E1 / E2 )      => freeVars(E1) freeVars(E2)
+  rule freeVars( E1 + E2 )      => freeVars(E1) freeVars(E2)
+  rule freeVars( E1 <= E2 )     => freeVars(E1) freeVars(E2)
+  rule freeVars( if B then E1 else E2) => freeVars(B) freeVars(E1) freeVars(E2)
 
+  syntax Id ::= freshVar(Id, Int, Set) [function]
+  rule freshVar(V, I, S) => #let X = String2Id(Id2String(V) +String Int2String(I)) #in #if X in S #then freshVar(V, I +Int 1, S) #else X #fi
+
+  syntax Exp ::= Exp "[" Exp "/" Id "]" [function]
+
+  rule X:Exp [_ / _] => X [owise]
   rule X [V / X] => V
 
-  rule (lambda X . E) [V / Y] => lambda X . (E[V / Y])
+  rule (lambda Y . E) [_ / Y] => lambda Y . E
+  rule (lambda Y . E) [V / X] => lambda Y . (E[V / X]) requires Y =/=K X andBool notBool (Y in freeVars(V))
+  rule (lambda Y . E) [V / X] => #let Z = freshVar(Y, 0, freeVars(E) freeVars(V)) #in lambda Z . (E[Z / Y] [V / X])
+    requires Y =/=K X andBool Y in freeVars(V)
 
   rule (E1:Exp E2:Exp) [V / X] => E1[V / X] (E2[V / X])
 
@@ -159,7 +174,7 @@ module LAMBDA
 
   rule (if C then E1 else E2) [V / X] => if C[V / X] then E1[V / X] else (E2[V / X])
 
-  rule (lambda X:KVar . E:Exp) V:Val => E[V / X]
+  rule (lambda X:Id . E:Exp) V:Val => E[V / X]
 ```
 
 ### Integer Builtins

--- a/1_k/1_lambda/lesson_9/tests/closed-variable-capture.lambda.out
+++ b/1_k/1_lambda/lesson_9/tests/closed-variable-capture.lambda.out
@@ -1,3 +1,3 @@
 <k>
-  lambda y . ( ( lambda x . lambda y0 . ( x y0 ) ) y ) ~> .
+  lambda y . ( ( lambda x . lambda y . ( x y ) ) y ) ~> .
 </k>


### PR DESCRIPTION
This replaces the substitution function `E[V / X]` from the `SUBSTITUTION` module with manually defined semantics for it in the lambda lessons. It's possible that the `SUBSTITUTION` module will eventually be dropped from K, so this PR is the beginning of preparation/discovery for making such a change.

Notes:
- The `binder` attribute and `KVar` hooked sort from `substitution.md` is still being used for renaming variables that have duplicate names. Without them, then the free variable capture example (`a (((lambda x.lambda y.x) y) z)`) will evaluate incorrectly to `a z` instead of `a y`. @ehildenb Is there an alternative option here?
- The lesson texts are still teaching and referring to the builtin substitution, and need to be rewritten.