### PR TITLE
README: Fix link to K Overview video

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Here you will learn how to use the K tool to define languages by means of a seri
 
 Make sure you watch the K overview video before you do the K tutorial:
 
-- [9'59"] [K Overview](../../overview.md)
+- [9'59"] [K Overview](https://youtu.be/eSaIKHQOo4c)
 
 ## Learning K
 


### PR DESCRIPTION
This was doing a relative link outside of the repo (two levels up) to an `overview.md` file. I am guessing that this is probably intending to be the `web/pages/overview.md` from the K repo.[1] That file links to the YouTube URL I've now put in here.

[1]: https://github.com/runtimeverification/k.git